### PR TITLE
Update landsat_collection2.py

### DIFF
--- a/rio_tiler_pds/landsat/aws/landsat_collection2.py
+++ b/rio_tiler_pds/landsat/aws/landsat_collection2.py
@@ -29,7 +29,9 @@ from morecantile import TileMatrixSet
 
 from rio_tiler.constants import WEB_MERCATOR_TMS, WGS84_CRS
 from rio_tiler.errors import InvalidBandName
-from rio_tiler.io import COGReader, MultiBandReader
+# to avoid rasterio cannot open s3 file
+from rio_tiler_fs.reader import COGReader
+from rio_tiler.io import  MultiBandReader
 from rio_tiler_pds.landsat.utils import sceneid_parser
 from rio_tiler_pds.utils import get_object
 


### PR DESCRIPTION
use rio_tiler_fs COGReader instead of rio_tiler.io COGReader to handle potential issue with S3